### PR TITLE
Add a GH action to publish updates when main changes.

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,24 @@
+name: Push to GitHub Pages on push to main
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - name: Deploy the site
+        uses: benmatselby/hugo-deploy-gh-pages@master
+        env:
+          HUGO_VERSION: 0.74.3
+          TARGET_REPO: hackliza/hackliza.github.io
+          CNAME: hackliza.gal
+          TARGET_BRANCH: gh-pages
+          TOKEN: "ghtoken:${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Esta accion se dispara en actualizacion a rama `main`, e usa a accion [benmatselby/hugo-deploy-gh-pages](https://github.com/marketplace/actions/hugo-deploy-github-pages) para re-xenerar o blogue e pushealo a rama `gh-pages`.

Algo a ter en conta e que a accion pushea a actualizacion pisando os commits anteriores da rama `gh-pages` (podese ver [neste repo de proba](https://github.com/kenkeiras/hackliza.github.io/tree/gh-pages) que so hai un commit na rama). Asi que haberia que pensar como de importante e manter o historial desa rama.

Na miña opinion non deberia ser un problema, o fin e o cabo e o resultado de "compilar" o blogue, e non algo do que hai que manter o historial, pero estaria ben que alguen o confirmara. 